### PR TITLE
"DnsAdmins" group is under the "CN=Users" container by default (not at domain root)

### DIFF
--- a/Healthcheck/HealthcheckAnalyzer.cs
+++ b/Healthcheck/HealthcheckAnalyzer.cs
@@ -1159,7 +1159,7 @@ namespace PingCastle.Healthcheck
 					dnsAdminFound = true;
 				};
 			// we do a one level search just case the group is in the default position
-			adws.Enumerate(domainInfo.DefaultNamingContext, "(&(objectClass=group)(description=DNS Administrators Group))", properties, callback, "OneLevel");
+			adws.Enumerate("CN=Users," + domainInfo.DefaultNamingContext, "(&(objectClass=group)(description=DNS Administrators Group))", properties, callback, "OneLevel");
 			if (!dnsAdminFound)
 			{
 				// then full tree. This is an optimization for LDAP request


### PR DESCRIPTION
According to: https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/active-directory-security-groups#dnsadmins

In a normal domain, with "DnsAdmins" under "CN=Users", this first "OneLevel" search at domain root never returns something so PingCastle fallbacks to a full tree search.

This change also prevents some false positives if we have the normal DnsAdmins under CN=Users and other group with the same description somewhere else deeper in the tree.

Also, I'd be more confident using the well-known SID/RID, S-1-5-21-<domain>-1102 shown in the documentation, but it does not seem to be always respected even in new lab domains...