### PR TITLE
False positive on privileged delegable users

### DIFF
--- a/Healthcheck/Rules/HeatlcheckRulePrivilegedDelegated.cs
+++ b/Healthcheck/Rules/HeatlcheckRulePrivilegedDelegated.cs
@@ -22,8 +22,15 @@ namespace PingCastle.Healthcheck.Rules
             int adminCanBeDelegated = 0;
             foreach (var member in healthcheckData.AllPrivilegedMembers)
             {
-                if (member.CanBeDelegated && !member.IsInProtectedUser)
-                    adminCanBeDelegated++;
+                if (member.CanBeDelegated)
+                    if (healthcheckData.SchemaVersion < 69) 
+                    {
+                        adminCanBeDelegated++;
+                    }
+                    else if (!member.IsInProtectedUser)
+                    {
+                        adminCanBeDelegated++;
+                    }
             }
 			return adminCanBeDelegated;
         }

--- a/Healthcheck/Rules/HeatlcheckRulePrivilegedDelegated.cs
+++ b/Healthcheck/Rules/HeatlcheckRulePrivilegedDelegated.cs
@@ -22,7 +22,7 @@ namespace PingCastle.Healthcheck.Rules
             int adminCanBeDelegated = 0;
             foreach (var member in healthcheckData.AllPrivilegedMembers)
             {
-                if (member.CanBeDelegated)
+                if (member.CanBeDelegated && !member.IsInProtectedUser)
                     adminCanBeDelegated++;
             }
 			return adminCanBeDelegated;

--- a/Healthcheck/Rules/RuleDescription.resx
+++ b/Healthcheck/Rules/RuleDescription.resx
@@ -629,10 +629,10 @@ Second, a more manual way is to essentially reset the password manually once, th
     <value>Presence of service accounts in the domain admin group (at least {threshold} accounts have a password which never expire): {count}</value>
   </data>
   <data name="P_Delegated_Description" xml:space="preserve">
-    <value>The purpose is to ensure that all Administrator Accounts have the configuration flag "this account is sensitive and cannot be delegated"</value>
+    <value>The purpose is to ensure that all Administrator Accounts have the configuration flag "this account is sensitive and cannot be delegated" and are not member of the built-in group "Protected Users".</value>
   </data>
   <data name="P_Delegated_Solution" xml:space="preserve">
-    <value>To correct the situation, you should make sure that all your Administrator Accounts has the check-box "This account is sensitive and cannot be delegated" active. Please not that there is a section bellow in this report named "Admin Groups" which give more information.</value>
+    <value>To correct the situation, you should make sure that all your Administrator Accounts has the check-box "This account is sensitive and cannot be delegated" active or add your Administrator Accounts to the built-in group "Protected Users" (some functionalities may not work properly afterwards, you should check the <a href="https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/manage/how-to-configure-protected-accounts">official documentation</a>). Please note that there is a section bellow in this report named "Admin Groups" which give more information.</value>
   </data>
   <data name="P_Delegated_Rationale" xml:space="preserve">
     <value>Presence of Admin accounts which have not the flag "this account is sensitive and cannot be delegated": {count}</value>

--- a/Healthcheck/Rules/RuleDescription.resx
+++ b/Healthcheck/Rules/RuleDescription.resx
@@ -629,10 +629,10 @@ Second, a more manual way is to essentially reset the password manually once, th
     <value>Presence of service accounts in the domain admin group (at least {threshold} accounts have a password which never expire): {count}</value>
   </data>
   <data name="P_Delegated_Description" xml:space="preserve">
-    <value>The purpose is to ensure that all Administrator Accounts have the configuration flag "this account is sensitive and cannot be delegated" and are not member of the built-in group "Protected Users".</value>
+    <value>The purpose is to ensure that all Administrator Accounts have the configuration flag "this account is sensitive and cannot be delegated" (and are not member of the built-in group "Protected Users" when your domain functional level is at least Windows Server 2012 R2).</value>
   </data>
   <data name="P_Delegated_Solution" xml:space="preserve">
-    <value>To correct the situation, you should make sure that all your Administrator Accounts has the check-box "This account is sensitive and cannot be delegated" active or add your Administrator Accounts to the built-in group "Protected Users" (some functionalities may not work properly afterwards, you should check the <a href="https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/manage/how-to-configure-protected-accounts">official documentation</a>). Please note that there is a section bellow in this report named "Admin Groups" which give more information.</value>
+    <value>To correct the situation, you should make sure that all your Administrator Accounts has the check-box "This account is sensitive and cannot be delegated" active or add your Administrator Accounts to the built-in group "Protected Users" if your domain functional level is at least Windows Server 2012 R2 (some functionalities may not work properly afterwards, you should check the <a href="https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/manage/how-to-configure-protected-accounts">official documentation</a>). Please note that there is a section bellow in this report named "Admin Groups" which give more information.</value>
   </data>
   <data name="P_Delegated_Rationale" xml:space="preserve">
     <value>Presence of Admin accounts which have not the flag "this account is sensitive and cannot be delegated": {count}</value>


### PR DESCRIPTION
Hello there !
I noticed the rule `P_Delegated` is triggered when a user has the flag `accountNotDelegated` set to false AND is part of the `Protected Users` group. According to the [official documentation](https://docs.microsoft.com/fr-fr/windows-server/security/credentials-protection-and-management/protected-users-security-group#domain-controller-protections-for-protected-users), if the domain functional level is at least Microsoft Server 2012 R2 (schema version = 69), a protected user cannot be delegated even if the flag is set to false.
Here is a little check of the schema version, membership to `Protected Users` and the rule description/recommendation updated as a suggestion.