### PR TITLE
Add scanner computer version

### DIFF
--- a/PingCastle.csproj
+++ b/PingCastle.csproj
@@ -283,6 +283,7 @@
     <Compile Include="Rules\RuleSet.cs" />
     <Compile Include="Scanners\AntivirusScanner.cs" />
     <Compile Include="Scanners\bluekeepscanner.cs" />
+    <Compile Include="Scanners\ComputerVersion.cs" />
     <Compile Include="Scanners\ZeroLogonScanner.cs" />
     <Compile Include="Scanners\ExportUsersScanner.cs" />
     <Compile Include="Scanners\RemoteScanner.cs" />

--- a/Scanners/ComputerVersion.cs
+++ b/Scanners/ComputerVersion.cs
@@ -1,0 +1,42 @@
+﻿//
+// Copyright (c) Ping Castle. All rights reserved.
+// https://www.pingcastle.com
+//
+// Licensed under the Non-Profit OSL. See LICENSE file in the project root for full license information.
+//
+using PingCastle.ADWS;
+using PingCastle.misc;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
+
+namespace PingCastle.Scanners
+{
+	public class ComputerVersion : ScannerBase
+    {
+		public override string Name { get { return "computerversion"; } }
+
+		public override string Description { get { return "Get the version of a computer. Can be used to determine if obsolete operating systems are still present."; } }
+
+		override protected string GetCsvHeader()
+		{
+			return "Computer\tVersion";
+		}
+
+		override protected string GetCsvData(string computer)
+		{
+		    string version = NativeMethods.GetComputerVersion(computer);
+			if (version != "not found")
+			{
+				return computer + "\t" + version;
+			}
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
Hi,

This PR adds a new scanner to remotely retrieve the computer version.
It uses Netapi32 to retrieve information concerning the operating system from the remote server because we can't always trust data in Active Directory.