### PR TITLE
Fix aria collapsible with ampersand in id

### DIFF
--- a/Report/ReportBase.cs
+++ b/Report/ReportBase.cs
@@ -654,7 +654,7 @@ namespace PingCastle.Report
 
         protected virtual void GenerateSection(string title, GenerateContentDelegate generateContent)
         {
-            string id = "section" + title.Replace(" ", "");
+            string id = "section" + title.Replace(" ", "").Replace("&", "");
             Add(@"
 <!-- Section " + title + @" -->
 <div id=""" + id + @""">


### PR DESCRIPTION
At least in Chrome the section for "Mitre Att&ck®" cannot be collapsed as long as the ampersand is included. Perhaps you want to create a more generic method for keeping the ids free of special characters, perhaps this one helps in the first place.