### PR TITLE
Add access check for current user in the share scanner

### DIFF
--- a/shares/ShareEnumerator.cs
+++ b/shares/ShareEnumerator.cs
@@ -75,6 +75,52 @@ namespace PingCastle.shares
             return false;
         }
 
+        public static bool IsCurrentUserAllowed(string server, string share)
+        {
+            string path = "\\\\" + server + "\\" + share + "\\";
+            try
+            {
+                DirectoryInfo di = new DirectoryInfo(path);
+                // special case for the Users default folder
+                if (share.Equals("Users", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    foreach (DirectoryInfo di2 in di.GetDirectories())
+                    {
+                        if (di2.Name.Equals("Default", StringComparison.InvariantCultureIgnoreCase))
+                            continue;
+
+                        try
+                        {
+                            var files = System.IO.Directory.GetFiles(path);
+                            return true;
+                        }
+                        catch
+                        {
+                            continue;
+                        }
+                    }
+                    return false;
+                }
+                else
+                {
+                    try
+                    {
+                        var files = System.IO.Directory.GetFiles(path);
+                        return true;
+                    }
+                    catch
+                    {
+                        return false;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Trace.WriteLine(path + " " + ex.Message);
+            }
+            return false;
+        }
+
         public static bool IsSensitiveFilePresent(string server, string share)
         {
             string path = "\\\\" + server + "\\" + share + "\\";

--- a/shares/ShareScanner.cs
+++ b/shares/ShareScanner.cs
@@ -17,7 +17,7 @@ namespace PingCastle.shares
 
         override protected string GetCsvHeader()
         {
-            return "Computer\tShare\tIsEveryoneAllowed";
+            return "Computer\tShare\tIsEveryoneAllowed\tIsCurrentUserAllowed";
         }
 
         override protected string GetCsvData(string computer)
@@ -28,9 +28,10 @@ namespace PingCastle.shares
                 foreach (string path in ShareEnumerator.EnumShare(computer))
                 {
                     bool everyone = ShareEnumerator.IsEveryoneAllowed(computer, path);
+                    bool currentUser = ShareEnumerator.IsCurrentUserAllowed(computer, path);
                     if (!String.IsNullOrEmpty(output))
                         output += "\r\n";
-                    output += computer + "\t" + path + "\t" + everyone;
+                    output += computer + "\t" + path + "\t" + everyone + "\t" + currentUser;
                 }
             }
             return output;


### PR DESCRIPTION
Attempts to list the files (using `System.IO.Directory.GetFiles`) in the shares enumerated by the `share` scanner to check if the current user has access to the share.