### PR TITLE
Update HeatlcheckRulePrivilegedDNSAdmin.cs

### DIFF
--- a/Healthcheck/Rules/HeatlcheckRulePrivilegedDNSAdmin.cs
+++ b/Healthcheck/Rules/HeatlcheckRulePrivilegedDNSAdmin.cs
@@ -10,9 +10,9 @@ using PingCastle.Rules;
 namespace PingCastle.Healthcheck.Rules
 {
     [RuleModel("P-DNSAdmin", RiskRuleCategory.PrivilegedAccounts, RiskModelCategory.ACLCheck)]
-    [RuleComputation(RuleComputationType.TriggerOnPresence, 5)]
+    [RuleComputation(RuleComputationType.TriggerOnPresence, 0)]
     [RuleIntroducedIn(2, 9)]
-    [RuleDurANSSI(1, "dnsadmins", "DnsAdmins group members")]
+    [RuleDurANSSI(3, "dnsadmins", "DnsAdmins group members")]
     [RuleMitreAttackMitigation(MitreAttackMitigation.PrivilegedAccountManagement)]
     public class HeatlcheckRulePrivilegedDNSAdmin : RuleBase<HealthcheckData>
     {


### PR DESCRIPTION
This PR: 
- set maturity level to 3 : The Active Directory infrastructure does not appear to have been weakened from what default installation settings provide;
- set rule to informative

Related to issue #131 