### PR TITLE
[A-DCLdapSign] change scheme from `ldaps` to `ldap`

### DIFF
--- a/Healthcheck/HealthcheckAnalyzer.cs
+++ b/Healthcheck/HealthcheckAnalyzer.cs
@@ -4881,7 +4881,7 @@ namespace PingCastle.Healthcheck
                 Trace.WriteLine("Test ignored because tested on the DC itself");
                 return;
             }
-            var result = ConnectionTester.TestSignatureRequiredEnabled(new Uri("ldaps://" + dns), credentials);
+            var result = ConnectionTester.TestSignatureRequiredEnabled(new Uri("ldap://" + dns), credentials);
             if (result == ConnectionTesterStatus.SignatureNotRequired)
             {
                 DC.LdapServerSigningRequirementDisabled = true;


### PR DESCRIPTION
Hi Vincent !

The finding `A-DCLdapSign` currently checks LDAP signing configuration through the LDAPS protocol on TCP port 636.

In an environment without LDAP signing requirement where LDAPS is not configured (for instance if no ADCS is set up), the connection will fail and the finding will not show up in the report even though LDAP signing is not required.

This PR changes the scheme from `ldaps` to `ldap` to fix this issue.

Cheers !