### PR TITLE
fixed bug in T-SIDHistoryDangerous finding detection

### DIFF
--- a/Healthcheck/Rules/HeatlcheckRuleTrustSIDHistoryDangerous.cs
+++ b/Healthcheck/Rules/HeatlcheckRuleTrustSIDHistoryDangerous.cs
@@ -27,6 +27,7 @@ namespace PingCastle.Healthcheck.Rules
                 {
                     if (data.DangerousSID)
                     {
+                        count++;
                         AddRawDetail(data.FriendlyName);
                     }
                 }
@@ -38,6 +39,7 @@ namespace PingCastle.Healthcheck.Rules
                 {
                     if (data.DangerousSID)
                     {
+                        count++;
                         AddRawDetail(data.FriendlyName);
                     }
                 }

--- a/Healthcheck/Rules/HeatlcheckRuleTrustSIDHistoryDangerous.cs
+++ b/Healthcheck/Rules/HeatlcheckRuleTrustSIDHistoryDangerous.cs
@@ -27,7 +27,7 @@ namespace PingCastle.Healthcheck.Rules
                 {
                     if (data.DangerousSID)
                     {
-                        count++;
+                        count += data.Count;
                         AddRawDetail(data.FriendlyName);
                     }
                 }
@@ -39,7 +39,7 @@ namespace PingCastle.Healthcheck.Rules
                 {
                     if (data.DangerousSID)
                     {
-                        count++;
+                        count += data.Count;
                         AddRawDetail(data.FriendlyName);
                     }
                 }


### PR DESCRIPTION
As it stands, this rule is never triggered because of a small bug. The "count" variable that is returned is never incremented, so the check always returns 0.
This PR fixes it.