### PR TITLE
Exclude specified rule checks

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1197,6 +1197,7 @@ namespace PingCastle
             Console.WriteLine("");
             Console.WriteLine("    --datefile        : insert the date into the report filename");
             Console.WriteLine("    --encrypt         : use an RSA key stored in the .config file to crypt the content of the xml report");
+            Console.WriteLine("    --exclude <riskids> : comma delimited list of risk ids to exclude from the health check");
             Console.WriteLine("    --level <level>   : specify the amount of data found in the xml file");
             Console.WriteLine("                      : level: Full, Normal, Light");
             Console.WriteLine("    --no-enum-limit   : remove the max 100 users limitation in html report");

--- a/Program.cs
+++ b/Program.cs
@@ -464,14 +464,13 @@ namespace PingCastle
                                 requestedActions.Add(PossibleTasks.Export);
                             }
                             break;
-
-                        case "--exclude":
+                        case "--exclude-rules":
                             if (i + 1 >= args.Length)
                             {
-                                WriteInRed("argument for --exclude is mandatory");
+                                WriteInRed("argument for --exclude-rules is mandatory");
                                 return false;
                             }
-                            //List<string> excludedRules;
+
                             try
                             {
                                 settings.excludedRules = args[++i].Split(',')
@@ -1197,7 +1196,7 @@ namespace PingCastle
             Console.WriteLine("");
             Console.WriteLine("    --datefile        : insert the date into the report filename");
             Console.WriteLine("    --encrypt         : use an RSA key stored in the .config file to crypt the content of the xml report");
-            Console.WriteLine("    --exclude <riskids> : comma delimited list of risk ids to exclude from the health check");
+            Console.WriteLine("    --exclude-rules <riskids> : comma delimited list of risk ids to exclude from the health check");
             Console.WriteLine("    --level <level>   : specify the amount of data found in the xml file");
             Console.WriteLine("                      : level: Full, Normal, Light");
             Console.WriteLine("    --no-enum-limit   : remove the max 100 users limitation in html report");

--- a/Program.cs
+++ b/Program.cs
@@ -45,7 +45,7 @@ namespace PingCastle
         UploadAllRports,
         FakeReport,
         CloudHealthCheck,
-        ExportRulesXml
+        ExportRulesXml,
     }
 
     [LicenseProvider(typeof(PingCastle.ADHealthCheckingLicenseProvider))]

--- a/Rules/RuleSet.cs
+++ b/Rules/RuleSet.cs
@@ -17,6 +17,7 @@ namespace PingCastle.Rules
     public class RuleSet<T> where T : IRiskEvaluation
     {
         private static Dictionary<string, RuleBase<T>> _cachedRules = null;
+        private static Dictionary<string, RuleBase<T>> _cachedRulesExcluded = null;
         private static List<string> _excludedRuleIds = new List<string>();
 
         public IInfrastructureSettings InfrastructureSettings { get; set; }
@@ -33,13 +34,30 @@ namespace PingCastle.Rules
             }
         }
 
+        public static IEnumerable<RuleBase<T>> ExcludedRules
+        {
+            get
+            {
+                if (_cachedRulesExcluded == null || (_cachedRulesExcluded.Count == 0 && _excludedRuleIds.Count > 0))
+                {
+                    ReloadRules();
+                }
+                return _cachedRulesExcluded.Values;
+            }
+        }
+
         public static void ReloadRules()
         {
             _cachedRules = new Dictionary<string, RuleBase<T>>();
             LoadRules(_cachedRules);
         }
-
         public static void LoadRules(Dictionary<string, RuleBase<T>> rules)
+        {
+            _cachedRulesExcluded = new Dictionary<string, RuleBase<T>>();
+            LoadRules(rules, _cachedRulesExcluded);
+        }
+
+        public static void LoadRules(Dictionary<string, RuleBase<T>> rules, Dictionary<string, RuleBase<T>> excludedRules)
         {
             // important: to work with W2000, we cannot use GetType because it will instanciate .Net 3.0 class then load the missing assembly
             // the trick here is to check only the exported type and put as internal the class using .Net 3.0 functionalities
@@ -53,9 +71,12 @@ namespace PingCastle.Rules
                         if (_excludedRuleIds.Contains(a.RiskId))
                         {
                             Trace.WriteLine("Excluding " + a.RiskId + " from ruleset");
-                            continue;
+                            excludedRules.Add(a.RiskId, a);
                         }
-                        rules.Add(a.RiskId, a);
+                        else
+                        {
+                            rules.Add(a.RiskId, a);
+                        }
                     }
                     catch (Exception)
                     {
@@ -242,7 +263,6 @@ namespace PingCastle.Rules
             if (_cachedRules.ContainsKey(ruleid))
                 return _cachedRules[ruleid];
             return null;
-
         }
     }
 }

--- a/Rules/RuleSet.cs
+++ b/Rules/RuleSet.cs
@@ -29,11 +29,11 @@ namespace PingCastle.Rules
                 {
                     ReloadRules();
                 }
-                return _cachedRules.Values;
+                return _cachedRules.Values.Where(r => !_excludedRuleIds.Contains(r.RiskId));
             }
         }
 
-        public static IEnumerable<RuleBase<T>> IncludedRules
+        public static IEnumerable<RuleBase<T>> AllRules
         {
             get
             {
@@ -41,7 +41,7 @@ namespace PingCastle.Rules
                 {
                     ReloadRules();
                 }
-                return _cachedRules.Values.Where(r => !_excludedRuleIds.Contains(r.RiskId));
+                return _cachedRules.Values;
             }
         }
 

--- a/Rules/RuleSet.cs
+++ b/Rules/RuleSet.cs
@@ -7,7 +7,6 @@
 //
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;

--- a/RuntimeSettings.cs
+++ b/RuntimeSettings.cs
@@ -54,6 +54,8 @@ namespace PingCastle
 
         public string InitForExportAsGuest { get; set; }
 
+        public List<string> excludedRules = new List<string>();
+
         public string sendXmlTo;
         public string sendHtmlTo;
         public string sendAllTo;


### PR DESCRIPTION
First off, thanks for such a great tool! As I've been using with PingCastle, I've had a need to exclude certain rules that may show up in the environment, but that I don't care to include in the scoring (e.g. they are acceptable risks within the environment). I didn't see a way to *exclude specific rules*, so I tried to take the simplest approach to providing a method for accomplish that from the command line. 

Example: `PingCastle.exe --exclude-rules S-PwdLastSet-45,S-PwdLastSet-90`