### PR TITLE
Trim DisplaySpecifier path to avoid false positives

### DIFF
--- a/Healthcheck/Rules/HeatlcheckRulePrivilegedDisplaySpecifier.cs
+++ b/Healthcheck/Rules/HeatlcheckRulePrivilegedDisplaySpecifier.cs
@@ -29,7 +29,7 @@ namespace PingCastle.Healthcheck.Rules
                     var e = entry.AdminContextMenu.Split(',');
                     if (e.Length < 3)
                         continue;
-                    var path = e[2];
+                    var path = e[2].Trim();
                     if (!path.Contains("\\\\"))
                         continue;
 


### PR DESCRIPTION
Some environments I tested have the DisplaySpecifier string composed by entries separated by comma and space (`, `) instead of just comma (`,`).

Even if the configuration is accepted by Active Directory and the DisplaySpecifier script is correctly placed in the SYSVOL directory, PingCastle reports it as a vulnerability.

To fix the issue, I just ensure that the script path is trimmed, to avoid spaces messing up with the rule.