### PR TITLE
Add AdminSDHolder to critical infrastructure list

### DIFF
--- a/Graph/Reporting/GraphObjectReference.cs
+++ b/Graph/Reporting/GraphObjectReference.cs
@@ -85,6 +85,7 @@ namespace PingCastle.Graph.Reporting
                     new GraphSingleObject("CN=Users," + data.DefaultNamingContext,"Users container", CompromiseGraphDataObjectRisk.Medium),
                     new GraphSingleObject("CN=Computers," + data.DefaultNamingContext,"Computers container", CompromiseGraphDataObjectRisk.Medium),
                     new GraphSingleObject("CN=NTAuthCertificates,CN=Public Key Services,CN=Services," + data.ConfigurationNamingContext,"Certificate store", CompromiseGraphDataObjectRisk.Medium),
+                    new GraphSingleObject("CN=AdminSDHolder,CN=System," + data.DefaultNamingContext,"AdminSDHolder object", CompromiseGraphDataObjectRisk.Critical),
                 }},
                 {CompromiseGraphDataTypology.UserDefined, new List<GraphSingleObject>(){
                 }},


### PR DESCRIPTION
AdminSDHolder permissions are applied every 60 minutes to numerous protected groups in the domain. If the AdminSDHolder permissions are misconfigured, they will continually apply the same vulnerabilities to Domain Admins and other groups.

https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/plan/security-best-practices/appendix-c--protected-accounts-and-groups-in-active-directory#adminsdholder