### PR TITLE
Removed AzureADKerberos from MS14-068 Scanning

### DIFF
--- a/PingCastleCommon/Healthcheck/Rules/HeatlcheckRuleStaledMS14_068.cs
+++ b/PingCastleCommon/Healthcheck/Rules/HeatlcheckRuleStaledMS14_068.cs
@@ -32,7 +32,7 @@ namespace PingCastle.Healthcheck.Rules
             {
                 foreach (var domainController in healthcheckData.DomainControllers)
                 {
-                    if(domainController.DCName.Equals("AzureADKerberos", StringComparison.OrdinalIgnoreCase))
+                    if(domainController.AzureADKerberos)
                     {
                         Trace.WriteLine("S-Vuln-MS14-068: Skipping Azure AD Kerberos.");
                         continue;


### PR DESCRIPTION
<img width="1041" height="625" alt="image" src="https://github.com/user-attachments/assets/4b2d5ef2-6fd3-4311-a5c2-df771dce9a7b" />

## Summary
The rule S-Vuln-MS14-068 currently reports AzureADKerberos as a potentially vulnerable domain controller with the reason "KB3011780 patch status unknown". This is a false positive.
Background
AzureADKerberos is not a real Domain Controller. It is a special read-only Kerberos object automatically created by Azure AD Connect (or manually via AzureADKerberosServer PowerShell module) to enable Hybrid Azure AD Kerberos authentication (e.g. for passwordless FIDO2 sign-in and SSO from Azure AD-joined devices to on-premises resources).

## Characteristics of the AzureADKerberos object that make it immune to MS14-068:

It is represented as a krbtgt-like account (CN=AzureADKerberos,OU=Domain Controllers,...) and appears as a DC object in the directory, but it is not a real server — there is no actual machine running.
It has no associated operating system, no network interface, and cannot receive RPC/SMB connections.
KB3011780 is a kernel-level patch for a running Windows Server. It is not applicable to a virtual/synthetic object.
MS14-068 exploits the KDC service on a real, reachable DC. AzureADKerberos has no reachable KDC.

Reporting it as vulnerable misleads security teams and inflates the risk score by 100 points without any actionable remediation path.
## References

[Microsoft Docs – Azure AD Kerberos object](https://learn.microsoft.com/en-us/azure/active-directory/authentication/howto-authentication-passwordless-security-key-on-premises)