### PR TITLE
Fix typo: buitinDomain -> builtinDomain in LDAP filters

### DIFF
--- a/PingCastle/ADWS/ADWebService.cs
+++ b/PingCastle/ADWS/ADWebService.cs
@@ -218,7 +218,7 @@ namespace PingCastle.ADWS
                 foreach (string ou in OUToExplore)
                 {
                     output.Add(new OUExploration(ou, "OneLevel", i));
-                    Enumerate(ou, "(|(objectCategory=organizationalUnit)(objectCategory=container)(objectCategory=buitinDomain))", properties,
+                    Enumerate(ou, "(|(objectCategory=organizationalUnit)(objectCategory=container)(objectCategory=builtinDomain))", properties,
                         (ADItem x)
                         =>
                         {

--- a/PingCastle/Healthcheck/HealthcheckAnalyzer.cs
+++ b/PingCastle/Healthcheck/HealthcheckAnalyzer.cs
@@ -1628,7 +1628,7 @@ namespace PingCastle.Healthcheck
                     healthcheckData.Delegations.Clear();
                     healthcheckData.UnprotectedOU.Clear();
                 },
-                domainInfo.DefaultNamingContext, "(|(objectCategory=organizationalUnit)(objectCategory=container)(objectCategory=domain)(objectCategory=buitinDomain))", properties, callback, "SubTree");
+                domainInfo.DefaultNamingContext, "(|(objectCategory=organizationalUnit)(objectCategory=container)(objectCategory=domain)(objectCategory=builtinDomain))", properties, callback, "SubTree");
 
             adws.Enumerate(domainInfo.ConfigurationNamingContext, "(objectCategory=configuration)", properties, callback, "Base");
         }


### PR DESCRIPTION
The Builtin container (objectCategory=builtinDomain) was never matched due to the typo, so its delegations were excluded from health check.