### PR TITLE
Exclude 1601-01-01 (password never set) from PasswordDistribution

### DIFF
--- a/PingCastle/Healthcheck/HealthcheckAnalyzer.cs
+++ b/PingCastle/Healthcheck/HealthcheckAnalyzer.cs
@@ -628,7 +628,10 @@ namespace PingCastle.Healthcheck
                             // ex: guest, krbtgt for rodc, ...
                             if (x.WhenCreated != DateTime.MinValue)
                             {
-                                var i = ConvertPwdLastSetToKey(x);
+                                var dateTime = (x.PwdLastSet == DateTime.MinValue || x.PwdLastSet <= DateTime.FromFileTime(0))
+                                    ? x.WhenCreated
+                                    : x.PwdLastSet;
+                                var i = HealthcheckHelper.ConvertDateToKey(dateTime);
                                 if (pwdDistribution.ContainsKey(i))
                                     pwdDistribution[i]++;
                                 else
@@ -674,7 +677,7 @@ namespace PingCastle.Healthcheck
         private int ConvertPwdLastSetToKey(ADItem x)
         {
             var dateTime = x.PwdLastSet;
-            if (x.PwdLastSet == DateTime.MinValue)
+            if (x.PwdLastSet == DateTime.MinValue || x.PwdLastSet <= DateTime.FromFileTime(0))
                 dateTime = x.WhenCreated;
             return HealthcheckHelper.ConvertDateToKey(dateTime);
 
@@ -1453,8 +1456,8 @@ namespace PingCastle.Healthcheck
                 if (user.IsEnabled)
                 {
                     {
-                        var i = HealthcheckHelper.ConvertDateToKey(user.PwdLastSet == DateTime.MinValue ? user.Created : user.PwdLastSet);
-
+                        var dateTime = (user.PwdLastSet == DateTime.MinValue || user.PwdLastSet <= DateTime.FromFileTime(0)) ? user.Created : user.PwdLastSet;
+                        var i = HealthcheckHelper.ConvertDateToKey(dateTime);
                         if (pwdDistribution.ContainsKey(i))
                             pwdDistribution[i]++;
                         else


### PR DESCRIPTION
Accounts with pwdLastSet = 1601-01-01 (AD "never set") were counted in the password age distribution as ~5176 months old. Compare with DateTime.FromFileTime(0) (= 1601-01-01) and use WhenCreated as fallback so only real password ages are counted.