### PR TITLE
Fix duplicate-DC-DN crash in --generate-fake-reports (closes #352)

### DIFF
--- a/PingCastleCommon/Healthcheck/FakeHealthCheckDataGenerator.cs
+++ b/PingCastleCommon/Healthcheck/FakeHealthCheckDataGenerator.cs
@@ -469,7 +469,7 @@ namespace PingCastle.Healthcheck
                 dc.CreationDate = DateBetween2Dates(healthcheckData.DomainCreation, DateTime.Now);
                 // last logon timestam can have a delta of 14 days
                 dc.LastComputerLogonDate = DateTime.Now.AddDays(-1 * rnd.Next(180));
-                dc.DistinguishedName = "DC=DC";
+                dc.DistinguishedName = "CN=" + dc.DCName + ",OU=Domain Controllers,DC=" + healthcheckData.DomainFQDN.Replace(".", ",DC=");
                 dc.OperatingSystem = "Windows 2019";
                 healthcheckData.DomainControllers.Add(dc);
             }


### PR DESCRIPTION
## What

Closes #352. One-line fix in `FakeHealthCheckDataGenerator.cs:472`: replaces the hardcoded `dc.DistinguishedName = "DC=DC"` with a per-DC unique, properly-formed AD DC DN that includes the domain FQDN.

```diff
-                dc.DistinguishedName = "DC=DC";
+                dc.DistinguishedName = "CN=" + dc.DCName + ",OU=Domain Controllers,DC=" + healthcheckData.DomainFQDN.Replace(".", ",DC=");
```

Produces DNs like `CN=DC0,OU=Domain Controllers,DC=government-eye-place,DC=com` — per-DC unique, properly suffixed by the domain's FQDN.

## Why

`HeatlcheckRuleAnomalyAuditDC.AnalyzeDataNew` (`PingCastleCommon/Healthcheck/Rules/HeatlcheckRuleAnomalyAuditDC.cs:78-99`) builds a `Dictionary<string, ...>` keyed by `dc.DistinguishedName`. With the hardcoded `"DC=DC"` constant, the second `.Add()` for any multi-DC domain throws `ArgumentException: An item with the same key has already been added`. Result: `--generate-fake-reports` crashes ~50× per default-population run — every Medium and Large domain has ≥2 DCs (per the `(int)Math.Exp(Math.Log10(size) / 2)` formula at line 462).

## When the bug was introduced

Pre-existing — **not a 3.5.1.31 regression**. Identical hardcoded `dc.DistinguishedName = "DC=DC"` at the same location in 3.5.0.44 (verified via `git show 3.5.0.44:PingCastleCommon/Healthcheck/FakeHealthCheckDataGenerator.cs`). Neither this file nor `HeatlcheckRuleAnomalyAuditDC.cs` changed between 3.5.0.44 and 3.5.1.31. The bug has been latent — `--generate-fake-reports` is an undocumented CLI flag, so multi-DC paths likely haven't been exercised by community usage.

## Blast radius

Grepped all rules touching `dc.DistinguishedName`:

| File | Use | Affected by fix |
|---|---|---|
| `HeatlcheckRuleAnomalyAuditDC.cs:81` | Dict key | Fixed (unique keys) |
| `HeatlcheckRulePrivilegedDCOwner.cs:29` | Emit-only (`AddRawDetail`) | No semantic change |
| `HeatlcheckRulePrivilegedUnconstrainedDelegation.cs:28-41` | HashSet dedup | Improves (per-DC entries instead of silently collapsing to 1) |

`IsGPOAppliedToDC`'s `DCdn.EndsWith(ou)` check at `HeatlcheckRuleAnomalyAuditDC.cs:154` continues to work since the new DN is a valid suffix-matchable DN.

Live-scan path (`PingCastle/Healthcheck/HealthcheckAnalyzer.cs`) is unaffected — DNs there come from real AD via ADWS.

## Repro before fix

```powershell
.\PingCastle.exe --generate-fake-reports
```

Stack trace cited in #352. Roughly 50 exceptions per default run.